### PR TITLE
invalid token doesn't need cache, fix potential TypeError

### DIFF
--- a/fastocr/service.py
+++ b/fastocr/service.py
@@ -33,12 +33,13 @@ class BaiduOcr(BaseOcr):
                 return token_data.get('token', '')
         token, expires_in = await self.get_token()
         timestamp = int(time())
-        with self.TOKEN_FILE.open('w') as f:
-            json.dump({
-                'token': token,
-                'expires_in': expires_in,
-                'timestamp': timestamp
-            }, f)
+        if expires_in:
+            with self.TOKEN_FILE.open('w') as f:
+                json.dump({
+                    'token': token,
+                    'expires_in': expires_in,
+                    'timestamp': timestamp
+                }, f)
         return token
 
     async def get_token(self):


### PR DESCRIPTION
For Baidu OCR, `token` and `expires_in` in `.cache/fastocr/baidu_token_data.json` will be `null` if wrong API (or empty API) is given, where there's no need to save token in the cache file. (Otherwise it can raise a TypeError during `timestamp + expires_in`)